### PR TITLE
Add support to multiple sourceRoots

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 								"default": null
 							},
 							"sourceRoot": {
-								"type": "string",
+								"type": ["string", "array"],
 								"description": "script source root directory. to be used in souce file matching at breakpoints.",
 								"default": "${workspaceFolder}"
 							},
@@ -145,7 +145,10 @@
 								"default": 21110
 							},
 							"sourceRoot": {
-								"type": "string",
+								"type": [
+									"string",
+									"array"
+								],
 								"description": "script source root directory.",
 								"default": "${workspaceFolder}"
 							},

--- a/src/lrdbDebug.ts
+++ b/src/lrdbDebug.ts
@@ -21,7 +21,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 
 	useInternalLua?: boolean;
 	port: number;
-	sourceRoot?: string;
+	sourceRoot?: string | string[];
 	stopOnEntry?: boolean;
 }
 
@@ -29,7 +29,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
 	host: string;
 	port: number;
-	sourceRoot: string;
+	sourceRoot: string | string[];
 
 	stopOnEntry?: boolean;
 }
@@ -234,7 +234,7 @@ class LRDBChildProcessClient {
 
 class LuaDebugSession extends DebugSession {
 
-	// Lua 
+	// Lua
 	private static THREAD_ID = 1;
 
 	private _debug_server_process: ChildProcess;
@@ -293,7 +293,7 @@ class LuaDebugSession extends DebugSession {
 		this.sendResponse(response);
 	}
 
-	private setupSourceEnv(sourceRoot: string) {
+	private setupSourceEnv(sourceRoot: string[]) {
 		this.convertClientLineToDebugger = (line: number): number => {
 			return line;
 		}
@@ -302,7 +302,7 @@ class LuaDebugSession extends DebugSession {
 		}
 
 		this.convertClientPathToDebugger = (clientPath: string): string => {
-			return path.relative(sourceRoot, clientPath);
+			return path.relative(sourceRoot[0], clientPath);
 		}
 		this.convertDebuggerPathToClient = (debuggerPath: string): string => {
 			if (!debuggerPath.startsWith("@")) { return ''; }
@@ -311,7 +311,7 @@ class LuaDebugSession extends DebugSession {
 				return filename;
 			}
 			else {
-				return path.join(sourceRoot, filename);
+				return path.join(sourceRoot[0], filename);
 			}
 		}
 	}
@@ -319,7 +319,12 @@ class LuaDebugSession extends DebugSession {
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
 		this._stopOnEntry = args.stopOnEntry;
 		const cwd = args.cwd ? args.cwd : process.cwd();
-		const sourceRoot = args.sourceRoot ? args.sourceRoot : cwd;
+		var sourceRoot = args.sourceRoot ? args.sourceRoot : cwd;
+
+		if (typeof (sourceRoot) === "string") {
+			sourceRoot = [sourceRoot];
+		}
+
 		this.setupSourceEnv(sourceRoot);
 		const programArg = args.args ? args.args : [];
 
@@ -372,7 +377,13 @@ class LuaDebugSession extends DebugSession {
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
 		this._stopOnEntry = args.stopOnEntry;
-		this.setupSourceEnv(args.sourceRoot);
+		var sourceRoot = args.sourceRoot;
+
+		if (typeof (sourceRoot) === "string") {
+			sourceRoot = [sourceRoot];
+		}
+
+		this.setupSourceEnv(sourceRoot);
 
 		this._debug_client = new LRDBTCPClient(args.port, args.host);
 		this._debug_client.on_event = (event: DebugServerEvent) => { this.handleServerEvents(event) };
@@ -699,7 +710,7 @@ class LuaDebugSession extends DebugSession {
 		});
 		/*	}
 			else {
-	
+
 				response.body = {
 					result: `evaluate(context: '${args.context}', '${args.expression}')`,
 					variablesReference: 0

--- a/src/lrdbDebug.ts
+++ b/src/lrdbDebug.ts
@@ -9,11 +9,6 @@ import { fork, spawn, ChildProcess } from 'child_process';
 import * as net from 'net';
 import * as path from 'path';
 
-import * as os from 'os';
-import * as stream from 'stream';
-import { stringify } from 'querystring';
-
-
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 
 	program: string;


### PR DESCRIPTION
Hi! I and @robspsj are needing the multiple souceRoots feature ( #6 ).
This is really useful for adding breakpoints or debugging a file that is not within the project root.
So, this PR adds support to input a string or a string array of sourceRoots in debug attributes.
Some checks are performed to determine the absolute path of which root the file belongs to.
