### PR TITLE
add sourceFileMap launch property

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "TypeScript Compile"
         },
 		{
 			"type": "node",
@@ -32,7 +32,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "TypeScript Compile"
         },
 		{
 			"type": "node",
@@ -49,7 +49,7 @@
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
 			"internalConsoleOptions": "openOnSessionStart",
-            "preLaunchTask": "npm"
+            "preLaunchTask": "TypeScript Compile"
 		}
     ],
 	"compounds": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,31 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
 
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "tasks": [
+        {
+            "label": "TypeScript Compile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "isBackground": false,
+            "type": "shell",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared"
+            },
+            "command": "npm",
+            "args": [
+                "run",
+                "compile",
+                "--loglevel",
+                "silent"
+            ],
+            "problemMatcher": "$tsc-watch"
+        }
+    ]    
 }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ launch.json example:
             "program": "${file}",
             "cwd": "${workspaceFolder}",
             "stopOnEntry": true
+        },
+        {
+            "type": "lrdb",
+            "request": "attach",
+            "host": "192.168.1.28",
+            "port": 21110,
+            "name": "attach to remote debugger",
+            "sourceRoot": "${workspaceFolder}",
+            "sourceFileMap": {
+                "${workspaceFolder}": "/mnt/luadb_b/"
+            }
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -117,9 +117,16 @@
 								"default": null
 							},
 							"sourceRoot": {
-								"type": ["string", "array"],
-								"description": "script source root directory. to be used in souce file matching at breakpoints.",
+								"type": "string",
+								"description": "script source root directory.",
 								"default": "${workspaceFolder}"
+							},
+							"sourceFileMap": {
+								"type": "object",
+								"description": "Optional source file mappings passed to the debug engine. Example: '{ \"/original/source/path\":\"/current/source/path\" }'",
+								"default": {
+								  "<source-path>": "<target-path>"
+								}
 							},
 							"stopOnEntry": {
 								"type": "boolean",
@@ -145,12 +152,16 @@
 								"default": 21110
 							},
 							"sourceRoot": {
-								"type": [
-									"string",
-									"array"
-								],
+								"type": "string",
 								"description": "script source root directory.",
 								"default": "${workspaceFolder}"
+							},
+							"sourceFileMap": {
+								"type": "object",
+								"description": "Optional source file mappings passed to the debug engine. Example: '{ \"/original/source/path\":\"/current/source/path\" }'",
+								"default": {
+								  "<source-path>": "<target-path>"
+								}
 							},
 							"stopOnEntry": {
 								"type": "boolean",

--- a/src/lrdbDebug.ts
+++ b/src/lrdbDebug.ts
@@ -10,14 +10,14 @@ import * as net from 'net';
 import * as path from 'path';
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
-
 	program: string;
 	args: string[];
 	cwd: string;
 
 	useInternalLua?: boolean;
 	port: number;
-	sourceRoot?: string | string[];
+	sourceRoot?: string;
+	sourceFileMap?: object;
 	stopOnEntry?: boolean;
 }
 
@@ -25,8 +25,8 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
 	host: string;
 	port: number;
-	sourceRoot: string | string[];
-
+	sourceRoot: string;
+	sourceFileMap?: object;
 	stopOnEntry?: boolean;
 }
 
@@ -289,7 +289,7 @@ export class LuaDebugSession extends DebugSession {
 		this.sendResponse(response);
 	}
 
-	private setupSourceEnv(sourceRoot: string[]) {
+	private setupSourceEnv(sourceRoot: string, sourceFileMap?: object) {
 		this.convertClientLineToDebugger = (line: number): number => {
 			return line;
 		}
@@ -298,35 +298,43 @@ export class LuaDebugSession extends DebugSession {
 		}
 
 		this.convertClientPathToDebugger = (clientPath: string): string => {
-			for (let index = 0; index < sourceRoot.length; index++) {
-				var root = sourceRoot[index];
-				var resolvedRoot = path.resolve(root);
-				var resolvedClient = path.resolve(clientPath);
-				if (resolvedClient.startsWith(resolvedRoot))
-				{
-					return path.relative(resolvedRoot, resolvedClient);
-				}
-			}
-			return path.relative(sourceRoot[0], clientPath);
-		}
-		this.convertDebuggerPathToClient = (debuggerPath: string): string => {
-			if (!debuggerPath.startsWith("@")) { return ''; }
-			const filename: string = debuggerPath.substr(1);
-			if (path.isAbsolute(filename)) {
-				return filename;
-			}
-			else {
+			if (sourceFileMap) {
+				for (const sourceFileMapSource of Object.keys(sourceFileMap)) {
+					const sourceFileMapTarget: string = sourceFileMap[sourceFileMapSource];
+					const resolvedSource = path.resolve(sourceFileMapSource);
+					const resolvedClient = path.resolve(clientPath);
 
-
-				if (sourceRoot.length > 1) {
-					for (let index = 0; index < sourceRoot.length; index++) {
-						var absolutePath = path.join(sourceRoot[index], filename);
-						if (existsSync(absolutePath)) {
-							return absolutePath
-						}
+					const relativePath = path.relative(resolvedSource, resolvedClient);
+					if (! relativePath.startsWith("..")) {
+						// BUG: LRDB doesn't support absolute paths, returning only relative
+						//return path.join(sourceFileMapTarget, relativePath);
+						return relativePath;
 					}
 				}
-				return path.join(sourceRoot[0], filename);
+			}
+
+			return path.relative(sourceRoot, clientPath);
+		}
+
+		this.convertDebuggerPathToClient = (argDebuggerPath: string): string => {
+			if (!argDebuggerPath.startsWith("@")) { return ''; }
+			const debuggerPath = argDebuggerPath.substr(1);
+
+			if (sourceFileMap) {
+				for (const sourceFileMapSource of Object.keys(sourceFileMap)) {
+					const sourceFileMapTarget: string = sourceFileMap[sourceFileMapSource];
+
+					const relativePath = path.relative(sourceFileMapTarget, debuggerPath);
+					if (! relativePath.startsWith("..")) {
+						return path.join(sourceFileMapSource, relativePath);
+					}
+				}
+			}
+
+			if (path.isAbsolute(debuggerPath)) {
+				return debuggerPath;
+			} else {
+				return path.join(sourceRoot, debuggerPath);
 			}
 		}
 	}
@@ -335,12 +343,9 @@ export class LuaDebugSession extends DebugSession {
 		this._stopOnEntry = args.stopOnEntry;
 		const cwd = args.cwd ? args.cwd : process.cwd();
 		var sourceRoot = args.sourceRoot ? args.sourceRoot : cwd;
+		var sourceFileMap = args.sourceFileMap;
 
-		if (typeof (sourceRoot) === "string") {
-			sourceRoot = [sourceRoot];
-		}
-
-		this.setupSourceEnv(sourceRoot);
+		this.setupSourceEnv(sourceRoot, sourceFileMap);
 		const programArg = args.args ? args.args : [];
 
 		const port = args.port ? args.port : 21110;
@@ -394,12 +399,9 @@ export class LuaDebugSession extends DebugSession {
 		let args = oargs as AttachRequestArguments;
 		this._stopOnEntry = args.stopOnEntry;
 		var sourceRoot = args.sourceRoot;
+		var sourceFileMap = args.sourceFileMap;
 
-		if (typeof (sourceRoot) === "string") {
-			sourceRoot = [sourceRoot];
-		}
-
-		this.setupSourceEnv(sourceRoot);
+		this.setupSourceEnv(sourceRoot, sourceFileMap);
 
 		this._debug_client = new LRDBTCPClient(args.port, args.host);
 		this._debug_client.on_event = (event: DebugServerEvent) => { this.handleServerEvents(event) };


### PR DESCRIPTION
add sourceFileMap property for translating absolute paths between remote and local filesystems.
the same property is used in official vscode c++ extension/debugger.
the old method using multiple sourceRoot is undeterministic as it can find the same file in multiple directories.

this change makes the extension use absolute paths exclusively.

this PR is related to [LRDB PR 19](https://github.com/satoren/LRDB/pull/19)