### PR TITLE
[fix] fixed "Invalid variable attributes" error on variable inspector

### DIFF
--- a/src/lrdbDebug.ts
+++ b/src/lrdbDebug.ts
@@ -511,7 +511,7 @@ export class LuaDebugSession extends DebugSession {
       variablesData.forEach((v,i) => {
         const typename = typeof v
         const k = i + 1
-        const varRef = (typename == 'object') ? this._variableHandles.create(evalParam(k)) : undefined
+        const varRef = (typename == 'object') ? this._variableHandles.create(evalParam(k)) : 0
         variables.push({
           name: `${k}`,
           type: typename,
@@ -522,7 +522,7 @@ export class LuaDebugSession extends DebugSession {
     } else if (typeof variablesData === 'object') {
       for (const k in variablesData) {
         const typename = typeof variablesData[k]
-        const varRef =  (typename == 'object') ? this._variableHandles.create(evalParam(k)) : undefined
+        const varRef =  (typename == 'object') ? this._variableHandles.create(evalParam(k)) : 0
         variables.push({
           name: k,
           type: typename,


### PR DESCRIPTION
**before**
```json
{
    "seq": 0,
    "type": "response",
    "request_seq": 12,
    "command": "variables",
    "success": true,
    "body": {
        "variables": [
            {
                "name": "level",
                "type": "number",
                "value": "1"
            }
        ]
    }
}
```
![before](https://user-images.githubusercontent.com/3835355/137046607-0af426fa-d7ef-4a13-82ce-88ad383bf9f8.png)
**after**
```json
{
    "seq": 0,
    "type": "response",
    "request_seq": 13,
    "command": "variables",
    "success": true,
    "body": {
        "variables": [
            {
                "name": "level",
                "type": "number",
                "value": "1",
                "variablesReference": 0
            }
        ]
    }
}
```
![after](https://user-images.githubusercontent.com/3835355/137046662-617b9254-3ea9-4caa-9be3-29deeff767f9.png)

